### PR TITLE
Fixed geqe-comm error

### DIFF
--- a/geqe-comm/GeqeRunner.py
+++ b/geqe-comm/GeqeRunner.py
@@ -3,6 +3,7 @@ from pyspark.sql import SQLContext
 import sys
 sys.path.append('.')
 sys.path.append('lib')
+sys.path.append('geqe-ml')
 sys.path.append('geqe-ml/lib')
 import argparse
 import GeqeAPI


### PR DESCRIPTION
Jobs failing with error in GeqeRunner.py 'findSimilarPlaces' module not found. Occurs only when GeqeConsumer is configured to submit jobs to spark using yarn cluster. Error does not appear when GeqeConsumer does spark-submit local.